### PR TITLE
Add and start using CLANG_CHECK_FUNC_NAME

### DIFF
--- a/src/TypeUtils.h
+++ b/src/TypeUtils.h
@@ -43,6 +43,12 @@ class CXXRecordDecl;
 class CXXBaseSpecifier;
 }
 
+// this is the recommended way to check for a fully-qualified function name.
+// it avoids building a std::string for getQualifiedNameAsString() in the likely case
+// that the method name already does not match:
+#define CLAZY_CHECK_FUNC_NAME(func, class, method) \
+  (func->getName() == #method && func->getQualifiedNameAsString() == #class "::" #method)
+
 namespace TypeUtils
 {
     /**

--- a/src/checks/level1/install-event-filter.cpp
+++ b/src/checks/level1/install-event-filter.cpp
@@ -45,7 +45,7 @@ void InstallEventFilter::VisitStmt(clang::Stmt *stmt)
         return;
 
     FunctionDecl *func = memberCallExpr->getDirectCallee();
-    if (!func || func->getQualifiedNameAsString() != "QObject::installEventFilter")
+    if (!func || !CLAZY_CHECK_FUNC_NAME(func, QObject, installEventFilter))
         return;
 
     Expr *expr = memberCallExpr->getImplicitObjectArgument();
@@ -62,7 +62,7 @@ void InstallEventFilter::VisitStmt(clang::Stmt *stmt)
     auto methods = Utils::methodsFromString(record, "eventFilter");
 
     for (auto method : methods) {
-        if (method->getQualifiedNameAsString() != "QObject::eventFilter") // It overrides it, probably on purpose then, don't warn.
+        if (!CLAZY_CHECK_FUNC_NAME(method, QObject, eventFilter)) // It overrides it, probably on purpose then, don't warn.
             return;
     }
 

--- a/src/checks/level1/qlatin1string-non-ascii.cpp
+++ b/src/checks/level1/qlatin1string-non-ascii.cpp
@@ -43,7 +43,7 @@ void QLatin1StringNonAscii::VisitStmt(clang::Stmt *stmt)
     auto constructExpr = dyn_cast<CXXConstructExpr>(stmt);
     CXXConstructorDecl *ctor = constructExpr ? constructExpr->getConstructor() : nullptr;
 
-    if (!ctor || ctor->getQualifiedNameAsString() != "QLatin1String::QLatin1String")
+    if (!ctor || !CLAZY_CHECK_FUNC_NAME(ctor, QLatin1String, QLatin1String))
         return;
 
     StringLiteral *lt = HierarchyUtils::getFirstChildOfType2<StringLiteral>(stmt);

--- a/src/checks/level1/returning-data-from-temporary.cpp
+++ b/src/checks/level1/returning-data-from-temporary.cpp
@@ -91,9 +91,9 @@ void ReturningDataFromTemporary::handleMemberCall(CXXMemberCallExpr *memberCall,
         return;
     const auto methodName = method->getQualifiedNameAsString();
 
-    if (methodName != "QByteArray::data" &&
-        methodName != "QByteArray::operator const char *" &&
-        methodName != "QByteArray::constData")
+    if (!CLAZY_CHECK_FUNC_NAME(method, QByteArray, data) &&
+        !CLAZY_CHECK_FUNC_NAME(method, QByteArray, operator const char *) &&
+        !CLAZY_CHECK_FUNC_NAME(method, QByteArray, constData))
         return;
 
 


### PR DESCRIPTION
Clazy checks so far have used the expensive getQualifiedNameAsString()
function which internally needs to build up a std::string from various
StringRefs, to check for fully-qualified function names.

The Clang-Tidy developers, however, recommend to first check the
function name via getName() (which returns a StringRef) and only upon
a successful match check the FQN, too.

Add a macro that implements this strategy. Can't use a real function,
since we needs to concatenate C string literals at compile time.

Not all instances of the pattern have been fixed. In a number of
places, the FQN is used to search in a list of names. These first need
to be decomposed.