### PR TITLE
Introduce autoconnect-slot, for detection of uic autoconnected slots

### DIFF
--- a/ClazySources.cmake
+++ b/ClazySources.cmake
@@ -36,6 +36,7 @@ set(CLAZY_CHECKS_SRCS
   ${CMAKE_CURRENT_LIST_DIR}/src/checks/level0/unused-non-trivial-variable.cpp
   ${CMAKE_CURRENT_LIST_DIR}/src/checks/level0/writingtotemporary.cpp
   ${CMAKE_CURRENT_LIST_DIR}/src/checks/level0/wrong-qglobalstatic.cpp
+  ${CMAKE_CURRENT_LIST_DIR}/src/checks/level1/autoconnect-slot.cpp
   ${CMAKE_CURRENT_LIST_DIR}/src/checks/level1/autounexpectedqstringbuilder.cpp
   ${CMAKE_CURRENT_LIST_DIR}/src/checks/level1/child-event-qobject-cast.cpp
   ${CMAKE_CURRENT_LIST_DIR}/src/checks/level1/connect-3arg-lambda.cpp

--- a/checks.json
+++ b/checks.json
@@ -152,6 +152,11 @@
         },
 
         {
+            "name"  : "autoconnect-slot",
+            "level" : 1,
+            "categories" : ["readability"]
+        },
+        {
             "name"  : "auto-unexpected-qstringbuilder",
             "level" : 1,
             "categories" : ["bug", "qstring"],

--- a/src/checks/level1/README-autoconnect-slot.md
+++ b/src/checks/level1/README-autoconnect-slot.md
@@ -1,0 +1,10 @@
+# autoconnect-slot
+
+Warns when use of the autoconnected slot behavior from uic generated setupUi() is detected.
+E.g. slots following the naming convention "on_btnRefresh_clicked()". 
+
+The connections are very fragile, since any changes to either the widget's name or type
+will cause the connection to silently fail without any compile time or run time warnings.
+
+Instead, explicit connections should be created for these slots to ensure compilation
+failures if changes to the widget would break the slot connections.

--- a/src/checks/level1/autoconnect-slot.cpp
+++ b/src/checks/level1/autoconnect-slot.cpp
@@ -1,0 +1,100 @@
+/*
+  This file is part of the clazy static checker.
+
+  Copyright (C) 2017 Sergio Martins <smartins@kde.org>
+
+  This library is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Library General Public
+  License as published by the Free Software Foundation; either
+  version 2 of the License, or (at your option) any later version.
+
+  This library is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  Library General Public License for more details.
+
+  You should have received a copy of the GNU Library General Public License
+  along with this library; see the file COPYING.LIB.  If not, write to
+  the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+  Boston, MA 02110-1301, USA.
+*/
+
+#include "autoconnect-slot.h"
+#include "QtUtils.h"
+#include "checkmanager.h"
+#include "ClazyContext.h"
+#include "AccessSpecifierManager.h"
+#include <regex>
+
+using namespace clang;
+using namespace std;
+
+
+AutoConnectSlot::AutoConnectSlot( const std::string &name, ClazyContext *context )
+  : CheckBase( name, context )
+{
+  context->enableAccessSpecifierManager();
+}
+
+void AutoConnectSlot::VisitDecl( Decl *decl )
+{
+  AccessSpecifierManager *a = m_context->accessSpecifierManager;
+  if ( !a )
+    return;
+
+  auto method = dyn_cast<CXXMethodDecl>( decl );
+  if ( !method )
+    return;
+
+  if ( method->isThisDeclarationADefinition() && !method->hasInlineBody() ) // Don't warn twice
+    return;
+
+  QtAccessSpecifierType specifierType = a->qtAccessSpecifierType( method );
+
+  if ( specifierType != QtAccessSpecifier_Slot )
+    return;
+
+  std::string name = method->getNameAsString();
+
+  static regex rx( R"(on_(.*)_(.*))" );
+  smatch match;
+  if ( !regex_match( name, match, rx ) )
+    return;
+
+  std::string objectName = match[1].str();
+
+  CXXRecordDecl *record = method->getParent();
+  if ( clang::FieldDecl *field = getClassMember( record, objectName ) )
+  {
+    QualType type = field->getType();
+
+    if ( QtUtils::isQObject( type ) )
+      emitWarning( decl, "Use of autoconnected UI slot: " + name );
+  }
+}
+
+clang::FieldDecl *AutoConnectSlot::getClassMember( CXXRecordDecl *record, const string &memberName )
+{
+  if ( !record )
+    return nullptr;
+
+  for ( auto field : record->fields() )
+  {
+    if ( field->getNameAsString() == memberName )
+      return field;
+  }
+
+  // Also include the base classes
+  for ( const CXXBaseSpecifier &base : record->bases() )
+  {
+    CXXRecordDecl *baseRecord = TypeUtils::recordFromBaseSpecifier( base );
+    if ( clang::FieldDecl *field = getClassMember( baseRecord, memberName ) )
+    {
+      return field;
+    }
+  }
+
+  return nullptr;
+}
+
+REGISTER_CHECK( "autoconnect-slot", AutoConnectSlot, CheckLevel1 )

--- a/src/checks/level1/autoconnect-slot.h
+++ b/src/checks/level1/autoconnect-slot.h
@@ -1,0 +1,41 @@
+/*
+  This file is part of the clazy static checker.
+
+  Copyright (C) 2017 Sergio Martins <smartins@kde.org>
+
+  This library is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Library General Public
+  License as published by the Free Software Foundation; either
+  version 2 of the License, or (at your option) any later version.
+
+  This library is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  Library General Public License for more details.
+
+  You should have received a copy of the GNU Library General Public License
+  along with this library; see the file COPYING.LIB.  If not, write to
+  the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+  Boston, MA 02110-1301, USA.
+*/
+
+#ifndef CLAZY_AUTOCONNECT_SLOT_H
+#define CLAZY_AUTOCONNECT_SLOT_H
+
+#include "checkbase.h"
+#include <string>
+
+/**
+ * See README-autoconnect-slot.md for more info.
+ */
+class AutoConnectSlot : public CheckBase
+{
+public:
+    explicit AutoConnectSlot(const std::string &name, ClazyContext *context);
+    void VisitDecl(clang::Decl *decl) override;
+private:
+
+    clang::FieldDecl *getClassMember( clang::CXXRecordDecl *record, const std::string &memberName );
+};
+
+#endif

--- a/tests/autoconnect-slot/config.json
+++ b/tests/autoconnect-slot/config.json
@@ -1,0 +1,7 @@
+{
+    "tests" : [
+        {
+            "filename" : "main.cpp"
+        }
+    ]
+}

--- a/tests/autoconnect-slot/main.cpp
+++ b/tests/autoconnect-slot/main.cpp
@@ -1,0 +1,37 @@
+#include <QtCore/QObject>
+#include "ui_widget.h"
+
+class MyObject : public QObject, private Ui::Widget
+{
+    Q_OBJECT
+public:
+    bool on_mButton_something(); // No warn
+
+public Q_SLOTS:
+    void slot1() const {} // No warn
+    void slot2_something() {} // No warn
+    void slot3_something_(); // No warn
+    void on_mButton_clicked(); // Warn
+    void on_button_clicked(); // Warn
+    void on_mButton_enabled(); // Warn
+    void on_mButton_released() {} // Warn
+    void on_mButton(); // No warn
+    void on_notButton_clicked(); // No warn
+    void on_mDouble_clicked(); // No warn - not a widget
+
+  private:
+
+    double mDouble;
+    QPushButton* button;
+
+};
+
+void MyObject::on_mButton_enabled() // OK, already warned
+{
+
+}
+
+void test()
+{
+    MyObject o;
+}

--- a/tests/autoconnect-slot/main.cpp.expected
+++ b/tests/autoconnect-slot/main.cpp.expected
@@ -1,0 +1,4 @@
+autoconnect-slot/main.cpp:14:5: warning: Use of autoconnected UI slot: on_mButton_clicked [-Wclazy-autoconnect-slot]
+autoconnect-slot/main.cpp:15:5: warning: Use of autoconnected UI slot: on_button_clicked [-Wclazy-autoconnect-slot]
+autoconnect-slot/main.cpp:16:5: warning: Use of autoconnected UI slot: on_mButton_enabled [-Wclazy-autoconnect-slot]
+autoconnect-slot/main.cpp:17:5: warning: Use of autoconnected UI slot: on_mButton_released [-Wclazy-autoconnect-slot]

--- a/tests/autoconnect-slot/ui_widget.h
+++ b/tests/autoconnect-slot/ui_widget.h
@@ -1,0 +1,43 @@
+/********************************************************************************
+** Form generated from reading UI file 'widget.ui'
+**
+** Created by: Qt User Interface Compiler version 5.7.1
+**
+** WARNING! All changes made in this file will be lost when recompiling UI file!
+********************************************************************************/
+
+#ifndef UI_WIDGET_H
+#define UI_WIDGET_H
+
+#include <QtCore/QVariant>
+#include <QtWidgets/QPushButton>
+
+QT_BEGIN_NAMESPACE
+
+class Ui_Widget
+{
+public:
+
+    QPushButton *mButton;
+
+    void setupUi(QWidget *Widget)
+    {
+        if (Widget->objectName().isEmpty())
+            Widget->setObjectName(QStringLiteral("Widget"));
+
+        mButton = new QPushButton();
+        mButton->setObjectName(QStringLiteral("mButton"));
+
+        QMetaObject::connectSlotsByName(Widget);
+    } // setupUi
+
+};
+
+namespace Ui {
+    class Widget: public Ui_Widget {};
+} // namespace Ui
+
+QT_END_NAMESPACE
+
+#endif // UI_WIDGET_H
+


### PR DESCRIPTION
Warns for use of slots with the naming convention "on_btnRefresh_clicked", which calls to the uic generated setupUi() method will automatically connect to the corresponding widget's signals.

These connections are very fragile, and do not trigger compile time or run time warnings when changes to the ui file (such as renaming, removal of widgets, or changing widget type) cause the autoconnection
to fail.

Better to use explicit connections instead.