### PR TITLE
Static library build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -116,15 +116,22 @@ macro(link_to_llvm name llvm_libs)
     target_link_libraries(${name} ${llvm_system_lib})
   endforeach()
 
-  if(MSVC)
+  if(WIN32)
     target_link_libraries(${name} version.lib)
   endif()
 endmacro()
 
+option(CLAZY_STATIC_PLUGIN_LIB "Build plugin into static library" OFF)
+set(PLUGIN_LINK_TYPE SHARED)
+
+if (CLAZY_STATIC_PLUGIN_LIB)
+  set(PLUGIN_LINK_TYPE STATIC)
+endif()
+
 macro(add_clang_plugin name)
   set(srcs ${ARGN})
 
-  add_library(${name} SHARED ${srcs})
+  add_library(${name} ${PLUGIN_LINK_TYPE} ${srcs})
 
   if(SYMBOL_FILE)
     set_target_properties(${name} PROPERTIES LINK_FlAGS "-exported_symbols_list ${SYMBOL_FILE}")

--- a/src/Clazy.cpp
+++ b/src/Clazy.cpp
@@ -370,5 +370,7 @@ unique_ptr<ASTConsumer> ClazyStandaloneASTAction::CreateASTConsumer(CompilerInst
    return unique_ptr<ASTConsumer>(astConsumer);
 }
 
+volatile int ClazyPluginAnchorSource = 0;
+
 static FrontendPluginRegistry::Add<ClazyASTAction>
 X("clang-lazy", "clang lazy plugin");

--- a/src/PreProcessorVisitor.h
+++ b/src/PreProcessorVisitor.h
@@ -42,6 +42,8 @@ namespace clang {
     class MacroArgs;
 }
 
+using uint = unsigned;
+
 class PreProcessorVisitor : public clang::PPCallbacks
 {
     PreProcessorVisitor(const PreProcessorVisitor &) = delete;


### PR DESCRIPTION
This changes allow you to build clazy plugin static library (I've tested it with msvc and mingw) to link it later to libclang (like clangTidy is linked currently)

In libclang it requires to add some code to force some symbols link, like those:
extern volatile int ClazyPluginAnchorSource;
static int ClazyPluginAnchorDestination = ClazyPluginAnchorSource;

and some more to register checks