### PR TITLE
Fix build

### DIFF
--- a/src/Utils.h
+++ b/src/Utils.h
@@ -27,6 +27,7 @@
 
 #include "clazy_export.h"
 
+#include <clang/Basic/SourceManager.h>
 #include <clang/AST/DeclCXX.h>
 #include <clang/AST/Expr.h>
 #include <clang/AST/ExprCXX.h>


### PR DESCRIPTION
Without this fix I was getting:
```
08:30 $ make && make install
Scanning dependencies of target ClangLazy
[  1%] Building CXX object CMakeFiles/ClangLazy.dir/src/checks/level0/qcolor-from-literal.cpp.o
In file included from /home/big/Documents/Github/clazy/src/StringUtils.h:29:0,
                 from /home/big/Documents/Github/clazy/src/checks/level0/qcolor-from-literal.cpp:22:
/home/big/Documents/Github/clazy/src/Utils.h: In function ‘bool Utils::isMainFile(const clang::SourceManager&, clang::SourceLocation)’:
/home/big/Documents/Github/clazy/src/Utils.h:280:21: error: invalid use of incomplete type ‘const class clang::SourceManager’
             loc = sm.getExpansionLoc(loc);

```