### PR TITLE
Fix test after typo fixing in last commit

### DIFF
--- a/tests/qlatin1string-non-ascii/main.cpp.expected
+++ b/tests/qlatin1string-non-ascii/main.cpp.expected
@@ -1,1 +1,1 @@
-qlatin1string-non-ascii/main.cpp:5:19: warning: QStringLiteral with non-ascii literal [-Wclazy-qlatin1string-non-ascii]
+qlatin1string-non-ascii/main.cpp:5:19: warning: QLatin1String with non-ascii literal [-Wclazy-qlatin1string-non-ascii]


### PR DESCRIPTION
It fixes up the test following 16af838716a243ed251f30f7f482353d79e3de70