### PR TITLE
Properly install man pages into the standard directory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -206,7 +206,7 @@ if (NOT CLAZY_BUILD_WITH_CLANG)
   install(FILES README.md COPYING-LGPL2.txt checks.json DESTINATION ${DOC_INSTALL_DIR})
 
   # Build docs
-  set(MAN_INSTALL_DIR "man/man1")
+  set(MAN_INSTALL_DIR "${SHARE_INSTALL_DIR}/man/man1")
   add_subdirectory(docs)
 
   if(CLAZY_BUILD_UTILS_LIB)


### PR DESCRIPTION
Previously it installs into /usr/man/man1 which is incorrect.
It should be /usr/share/man/man1 as specified in FHS[1].

\[1]: https://refspecs.linuxfoundation.org/FHS_3.0/fhs/ch04s11.html#usrsharemanManualPages