### PR TITLE
Corrected version numbers needed for clazy

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,14 +51,14 @@ You can get clazy from:
 
 ### Install dependencies
 - OpenSUSE tumbleweed: `zypper install cmake git-core llvm llvm-devel llvm-clang llvm-clang-devel`
-- Ubuntu-16.04: `apt install g++ cmake clang llvm-dev git-core libclang-3.8-dev qtbase5-dev`
+- Ubuntu-16.04: `apt install g++ cmake clang llvm-dev git-core libclang-3.9-dev qtbase5-dev`
 - Archlinux: `pacman -S make llvm clang python2 cmake qt5-base git gcc`
 - Fedora: be sure to *remove* the llvm-static package and only install the one with dynamic libraries
 - Other distros: Check llvm/clang build docs.
 
 ### Build and install clang
 clang and LLVM >= 3.9 are required.
-Use clazy v1.1 if you need 3.7 support, or v1.3 for 3.8 support.
+Use clazy v1.1 if you need 3.7 support, or v1.2 for 3.8 support.
 
 If your distro provides clang then you can skip this step.
 


### PR DESCRIPTION
Corrected the clazy version (should be 1.2 instead of 1.3) to be used with clang-3.8 and also the clang version (Should be 3.9 instead of 3.8) needed for latest one