### PR TITLE
Update link in README-function-args-by-ref.md

### DIFF
--- a/docs/checks/README-function-args-by-ref.md
+++ b/docs/checks/README-function-args-by-ref.md
@@ -13,5 +13,5 @@ This check supports adding missing `&` or `const-&` with:
 
 
 - [1] <http://www.macieira.org/blog/2012/02/the-value-of-passing-by-value/>
-- [2] <http://en.cppreference.com/w/cpp/concept/TriviallyCopyable>
+- [2] <https://en.cppreference.com/w/cpp/named_req/TriviallyCopyable>
 - [3] <http://www.cplusplus.com/reference/type_traits/is_trivially_destructible/>


### PR DESCRIPTION
The external link to TriviallyCopyable was outdated.