### PR TITLE
Add a YAML diagnostic exporter (like clang-tidy)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -113,6 +113,9 @@ macro(link_to_llvm name is_standalone)
   if(WIN32)
     target_link_libraries(${name} version.lib)
   endif()
+    target_link_libraries(${name} clangTooling)
+    target_link_libraries(${name} clangToolingCore)
+    target_link_libraries(${name} clangToolingRefactor)
 endmacro()
 
 macro(add_clang_plugin name)
@@ -216,6 +219,9 @@ else()
     ${CLAZY_PLUGIN_SRCS}
 
     LINK_LIBS
+    clangToolingCore
+    clangToolingInclusions
+    clangToolingRefactor
     clangFrontend
     clangDriver
     clangCodeGen

--- a/ClazySources.cmake
+++ b/ClazySources.cmake
@@ -5,6 +5,7 @@ set(CLAZY_LIB_SRC
   ${CMAKE_CURRENT_LIST_DIR}/src/SuppressionManager.cpp
   ${CMAKE_CURRENT_LIST_DIR}/src/ContextUtils.cpp
   ${CMAKE_CURRENT_LIST_DIR}/src/FixItUtils.cpp
+  ${CMAKE_CURRENT_LIST_DIR}/src/FixItExporter.cpp
   ${CMAKE_CURRENT_LIST_DIR}/src/LoopUtils.cpp
   ${CMAKE_CURRENT_LIST_DIR}/src/PreProcessorVisitor.cpp
   ${CMAKE_CURRENT_LIST_DIR}/src/QtUtils.cpp

--- a/src/Clazy.cpp
+++ b/src/Clazy.cpp
@@ -28,6 +28,7 @@
 #include "checkbase.h"
 #include "AccessSpecifierManager.h"
 #include "SourceCompatibilityHelpers.h"
+#include "FixItExporter.h"
 
 #include <clang/Frontend/FrontendPluginRegistry.h>
 #include <clang/Frontend/CompilerInstance.h>
@@ -167,6 +168,9 @@ bool ClazyASTConsumer::VisitStmt(Stmt *stm)
 
 void ClazyASTConsumer::HandleTranslationUnit(ASTContext &ctx)
 {
+    // FIXME: EndSourceFile() is called automatically, but not BeginsSourceFile()
+    m_context->exporter->BeginSourceFile(clang::LangOptions());
+
     if ((m_context->options & ClazyContext::ClazyOption_OnlyQt) && !m_context->isQt())
         return;
 

--- a/src/ClazyContext.h
+++ b/src/ClazyContext.h
@@ -52,6 +52,7 @@ class Decl;
 
 class AccessSpecifierManager;
 class PreProcessorVisitor;
+class FixItExporter;
 
 class ClazyContext
 {
@@ -181,6 +182,7 @@ public:
     const ClazyOptions options;
     const std::vector<std::string> extraOptions;
     clang::FixItRewriter *rewriter = nullptr;
+    FixItExporter *exporter = nullptr;
     bool allFixitsEnabled = false;
     std::string requestedFixitName;
     clang::CXXMethodDecl *lastMethodDecl = nullptr;

--- a/src/FixItExporter.cpp
+++ b/src/FixItExporter.cpp
@@ -1,0 +1,158 @@
+/*
+  This file is part of the clazy static checker.
+
+    Copyright (C) 2016 Sergio Martins <smartins@kde.org>
+    Copyright (C) 2016 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
+
+    This library is free software; you can redistribute it and/or
+    modify it under the terms of the GNU Library General Public
+    License as published by the Free Software Foundation; either
+    version 2 of the License, or (at your option) any later version.
+
+    This library is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    Library General Public License for more details.
+
+    You should have received a copy of the GNU Library General Public License
+    along with this library; see the file COPYING.LIB.  If not, write to
+    the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+    Boston, MA 02110-1301, USA.
+*/
+
+#include "FixItExporter.h"
+
+#include <clang/Frontend/FrontendDiagnostic.h>
+#include <clang/Tooling/DiagnosticsYaml.h>
+#include <clang/Basic/SourceManager.h>
+#include <clang/Rewrite/Frontend/FixItRewriter.h>
+
+#define DEBUG_FIX_IT_EXPORTER
+
+#ifdef DEBUG_FIX_IT_EXPORTER
+#include <iostream>
+#endif
+
+using namespace clang;
+
+FixItExporter::FixItExporter(DiagnosticsEngine &DiagEngine, SourceManager &SourceMgr, const LangOptions &LangOpts, FixItOptions *FixItOpts)
+    : DiagEngine(DiagEngine), SourceMgr(SourceMgr), LangOpts(LangOpts),
+      FixItOpts(FixItOpts) {
+    Owner = DiagEngine.takeClient();
+    Client = DiagEngine.getClient();
+    DiagEngine.setClient(this, false);
+}
+
+FixItExporter::~FixItExporter() {
+    DiagEngine.setClient(Client, Owner.release() != nullptr);
+}
+
+void FixItExporter::BeginSourceFile(const LangOptions &LangOpts, const Preprocessor *PP) {
+    if (Client)
+        Client->BeginSourceFile(LangOpts, PP);
+
+    const auto id = SourceMgr.getMainFileID();
+    const auto entry = SourceMgr.getFileEntryForID(id);
+    TUDiag.MainSourceFile = entry->getName();
+}
+
+bool FixItExporter::IncludeInDiagnosticCounts() const {
+  return Client ? Client->IncludeInDiagnosticCounts() : true;
+}
+
+void FixItExporter::EndSourceFile() {
+    if (Client)
+        Client->EndSourceFile();
+}
+
+tooling::Diagnostic FixItExporter::ConvertDiagnostic(const Diagnostic &Info)
+{
+    SmallString<100> TmpMessageText;
+    Info.FormatDiagnostic(TmpMessageText);
+    const auto MessageText = TmpMessageText.slice(0, TmpMessageText.find_last_of('[') - 1).str();
+    const auto CheckName = TmpMessageText.slice(TmpMessageText.find_last_of('[') + 3,
+                                        TmpMessageText.find_last_of(']')).str();
+    llvm::StringRef CurrentBuildDir; // Not needed?
+
+    tooling::Diagnostic ToolingDiag(CheckName,
+                                    tooling::Diagnostic::Warning,
+                                    CurrentBuildDir);
+    ToolingDiag.Message = tooling::DiagnosticMessage(MessageText, SourceMgr, Info.getLocation());
+    return ToolingDiag;
+}
+
+tooling::Replacement FixItExporter::ConvertFixIt(const FixItHint &Hint)
+{
+    tooling::Replacement Replacement;
+    if (Hint.CodeToInsert.empty()) {
+      if (Hint.InsertFromRange.isValid()) {
+          clang::SourceLocation b(Hint.InsertFromRange.getBegin()), _e(Hint.InsertFromRange.getEnd());
+          if (b.isMacroID())
+              b = SourceMgr.getSpellingLoc(b);
+          if (_e.isMacroID())
+              _e = SourceMgr.getSpellingLoc(_e);
+          clang::SourceLocation e(clang::Lexer::getLocForEndOfToken(_e, 0, SourceMgr, LangOpts));
+          StringRef Text(SourceMgr.getCharacterData(b),
+                         SourceMgr.getCharacterData(e)-SourceMgr.getCharacterData(b));
+          return tooling::Replacement(SourceMgr, Hint.RemoveRange, Text);
+      }
+      return tooling::Replacement(SourceMgr, Hint.RemoveRange, "");
+    }
+    return tooling::Replacement(SourceMgr, Hint.RemoveRange, Hint.CodeToInsert);
+}
+
+void FixItExporter::HandleDiagnostic(DiagnosticsEngine::Level DiagLevel, const Diagnostic &Info) {
+    // Default implementation (Warnings/errors count).
+    DiagnosticConsumer::HandleDiagnostic(DiagLevel, Info);
+
+    // Let origianl client do it's handling
+    if (Client)
+        Client->HandleDiagnostic(DiagLevel, Info);
+
+    // We only deal with warnings
+    if (DiagLevel != DiagnosticsEngine::Warning)
+        return;
+
+    // Convert and record this diagnostic
+    auto ToolingDiag = ConvertDiagnostic(Info);
+    for (unsigned Idx = 0, Last = Info.getNumFixItHints();
+         Idx < Last; ++Idx) {
+        const FixItHint &Hint = Info.getFixItHint(Idx);
+        const auto replacement = ConvertFixIt(Hint);
+#ifdef DEBUG_FIX_IT_EXPORTER
+        const auto FileName = SourceMgr.getFilename(Info.getLocation());
+        std::cerr << "Handling Fixit #" << Idx << " for " << FileName.str() << std::endl;
+        std::cerr << "F: "
+                  << Hint.RemoveRange.getBegin().printToString(SourceMgr) << ":"
+                  << Hint.RemoveRange.getEnd().printToString(SourceMgr) << " "
+                  << Hint.InsertFromRange.getBegin().printToString(SourceMgr) << ":"
+                  << Hint.InsertFromRange.getEnd().printToString(SourceMgr) << " "
+                  << Hint.BeforePreviousInsertions << " "
+                  << Hint.CodeToInsert << std::endl;
+        std::cerr << "R: " << replacement.toString() << std::endl;
+#endif
+        auto &Replacements = ToolingDiag.Fix[replacement.getFilePath()];
+        auto error = Replacements.add(ConvertFixIt(Hint));
+        if (error) {
+            Diag(Info.getLocation(), diag::note_fixit_failed);
+        }
+    }
+    TUDiag.Diagnostics.push_back(ToolingDiag);
+}
+
+void FixItExporter::Export() {
+    std::error_code EC;
+    llvm::raw_fd_ostream OS(TUDiag.MainSourceFile + ".yaml", EC, llvm::sys::fs::F_None);
+    llvm::yaml::Output YAML(OS);
+    YAML << TUDiag;
+}
+
+void FixItExporter::Diag(SourceLocation Loc, unsigned DiagID) {
+    // When producing this diagnostic, we temporarily bypass ourselves,
+    // clear out any current diagnostic, and let the downstream client
+    // format the diagnostic.
+    DiagEngine.setClient(Client, false);
+    DiagEngine.Clear();
+    DiagEngine.Report(Loc, DiagID);
+    DiagEngine.setClient(this, false);
+}

--- a/src/FixItExporter.h
+++ b/src/FixItExporter.h
@@ -1,0 +1,67 @@
+/*
+  This file is part of the clazy static checker.
+
+    Copyright (C) 2016 Sergio Martins <smartins@kde.org>
+    Copyright (C) 2016 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
+
+    This library is free software; you can redistribute it and/or
+    modify it under the terms of the GNU Library General Public
+    License as published by the Free Software Foundation; either
+    version 2 of the License, or (at your option) any later version.
+
+    This library is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    Library General Public License for more details.
+
+    You should have received a copy of the GNU Library General Public License
+    along with this library; see the file COPYING.LIB.  If not, write to
+    the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+    Boston, MA 02110-1301, USA.
+*/
+
+#ifndef CLAZY_FIX_IT_EXPORTER_H
+#define CLAZY_FIX_IT_EXPORTER_H
+
+#include <clang/Basic/Diagnostic.h>
+#include <clang/Tooling/Core/Diagnostic.h>
+
+namespace clang {
+class FixItOptions;
+}
+
+class FixItExporter : public clang::DiagnosticConsumer {
+public:
+    FixItExporter(clang::DiagnosticsEngine &DiagEngine, clang::SourceManager &SourceMgr,
+                  const clang::LangOptions &LangOpts, clang::FixItOptions *FixItOpts);
+
+    ~FixItExporter() override;
+
+    bool IncludeInDiagnosticCounts() const override;
+
+    void BeginSourceFile(const clang::LangOptions &LangOpts,
+                         const clang::Preprocessor *PP = nullptr) override;
+
+    void EndSourceFile() override;
+
+    void HandleDiagnostic(clang::DiagnosticsEngine::Level DiagLevel,
+                          const clang::Diagnostic &Info) override;
+
+    void Export();
+
+    /// Emit a diagnostic via the adapted diagnostic client.
+    void Diag(clang::SourceLocation Loc, unsigned DiagID);
+
+private:
+    clang::DiagnosticsEngine &DiagEngine;
+    clang::SourceManager &SourceMgr;
+    const clang::LangOptions &LangOpts;
+    clang::FixItOptions *FixItOpts;
+    DiagnosticConsumer *Client;
+    std::unique_ptr<DiagnosticConsumer> Owner;
+    clang::tooling::TranslationUnitDiagnostics TUDiag;
+    clang::tooling::Diagnostic ConvertDiagnostic(const clang::Diagnostic &Info);
+    clang::tooling::Replacement ConvertFixIt(const clang::FixItHint &Hint);
+};
+
+#endif // CLAZY_FIX_IT_EXPORTER_H


### PR DESCRIPTION
This idea of this PR is to add the equivalent of clang-tidy `-export-fixes=<filename>`.
This is currently rough, but it does generate fixit db files. I still need to do more testing, eg. clang-apply-replacement shows that not all fixes are correct. But most of them are, so it's not that bad.

Let me know if you're interested by this feature, any feedback welcome.