### PR TITLE
README.md: remove incorrect WARNING in front of README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-*WARNING:* master is the development branch. Please use the v1.6 branch.
-
 clazy v1.6
 ===========
 


### PR DESCRIPTION
It is a little typo but cofusing.

Note: in branch `1.6`