### PR TITLE
Update README-copyable-polymorphic.md

### DIFF
--- a/docs/checks/README-copyable-polymorphic.md
+++ b/docs/checks/README-copyable-polymorphic.md
@@ -21,7 +21,7 @@ void printNumber(Base b)
 
 (...)
 Derived d;
-foo(d);
+printNumber(d);
 
 ```
 


### PR DESCRIPTION
Make the example function call's name match its definition

**Note**: (Second try. Finally found the 1.6 branch, and my brain.)